### PR TITLE
template and logic for searching a term translation

### DIFF
--- a/themes/wp-portugal-tema/functions.php
+++ b/themes/wp-portugal-tema/functions.php
@@ -45,4 +45,10 @@ require_once( 'library/theme-support.php' );
 /** Add Header image */
 require_once( 'library/custom-header.php' );
 
+/** Custom functions */
+require_once( 'library/custom.php' );
+
+
+
+
 ?>

--- a/themes/wp-portugal-tema/js/custom/glossary.js
+++ b/themes/wp-portugal-tema/js/custom/glossary.js
@@ -1,0 +1,42 @@
+
+function search_term() {
+  
+  var term__text = jQuery("#term__text").val();
+      
+      
+      var actioncall = {
+        action: 'get_terms',
+        term_text: term__text,
+        getterms_nonce: MyAjax.gettermsNonce
+      };
+
+      jQuery.post(MyAjax.ajaxurl,actioncall , function(response) {
+        console.log(response);
+        
+         if( "" === response) {
+           document.getElementById('term__result').style.borderColor="red";
+           document.getElementById('term__result').innerHTML = "";
+         } else {
+           document.getElementById('term__result').style.borderColor="rgb(131, 213, 145)";
+           document.getElementById('term__result').innerHTML = response;
+         }
+        
+      }, 'json');
+        
+  }
+jQuery(document).ready(function() {
+  //TODO: don't block enter.
+  if(jQuery("#term__text").is(":focus")){
+
+  jQuery(window).keydown(function(event){
+    if(event.keyCode == 13) {
+      event.preventDefault();
+      search_term();
+      return false;
+    }
+  });
+  }
+});
+jQuery(document).on('change', '#term__text' ,function (event) {
+  search_term();  
+});

--- a/themes/wp-portugal-tema/js/custom/glossary.js
+++ b/themes/wp-portugal-tema/js/custom/glossary.js
@@ -26,7 +26,7 @@ function search_term() {
   }
 jQuery(document).ready(function() {
   //TODO: don't block enter.
-  if(jQuery("#term__text").is(":focus")){
+  //if(jQuery("#term__text").is(":focus")){
 
   jQuery(window).keydown(function(event){
     if(event.keyCode == 13) {
@@ -35,7 +35,8 @@ jQuery(document).ready(function() {
       return false;
     }
   });
-  }
+  //}
+  document.getElementById("term__text").focus();
 });
 jQuery(document).on('change', '#term__text' ,function (event) {
   search_term();  

--- a/themes/wp-portugal-tema/library/custom.php
+++ b/themes/wp-portugal-tema/library/custom.php
@@ -1,0 +1,31 @@
+<?php
+
+add_action('wp_ajax_get_terms','prefix_ajax_get_terms');
+add_action('wp_ajax_nopriv_get_terms','prefix_ajax_get_terms');
+
+function prefix_ajax_get_terms(){
+	if( !wp_verify_nonce( $_POST['getterms_nonce'] , 'myajax-term-nonce' ) ) {
+		die ( 'Not allowed.');
+	}
+	$term_text = sanitize_text_field($_POST['term_text']); 
+	
+	$solution  = "";
+	$uploaddir = wp_upload_dir();
+	if (($handle = fopen($uploaddir['baseurl']."/glossario.csv", "r")) !== FALSE) {
+    while (($data = fgetcsv($handle, 1000, ",")) !== FALSE) {
+    	if( mb_strtolower($data[0]) === mb_strtolower($term_text)) {
+    	  $solution = $data[1];
+    	} 
+    }
+    fclose($handle);
+	}
+
+	$response = json_encode( $solution  );
+ 
+  // send response 
+  header( "Content-Type: application/json" );
+  echo $response;
+	
+	die();
+	
+}

--- a/themes/wp-portugal-tema/library/enqueue-scripts.php
+++ b/themes/wp-portugal-tema/library/enqueue-scripts.php
@@ -38,6 +38,13 @@ if ( ! function_exists( 'foundationpress_scripts' ) ) :
 	wp_enqueue_script( 'jquery' );
 	wp_enqueue_script( 'foundation' );
 
+	//TODO: do a conditional load on page id
+	//wp_enqueue_script( 'glossary', get_template_directory_uri() . '/js/custom/glossary.js', array( 'jquery' ), '20150330', true );
+	wp_localize_script( 'foundation', 'MyAjax', 
+  	array( 'ajaxurl' => admin_url( 'admin-ajax.php' ),
+    	   'gettermsNonce' => wp_create_nonce( 'myajax-term-nonce' ),
+	 ) );
+
 	}
 
 	add_action( 'wp_enqueue_scripts', 'foundationpress_scripts' );

--- a/themes/wp-portugal-tema/library/enqueue-scripts.php
+++ b/themes/wp-portugal-tema/library/enqueue-scripts.php
@@ -39,7 +39,6 @@ if ( ! function_exists( 'foundationpress_scripts' ) ) :
 	wp_enqueue_script( 'foundation' );
 
 	//TODO: do a conditional load on page id
-	//wp_enqueue_script( 'glossary', get_template_directory_uri() . '/js/custom/glossary.js', array( 'jquery' ), '20150330', true );
 	wp_localize_script( 'foundation', 'MyAjax', 
   	array( 'ajaxurl' => admin_url( 'admin-ajax.php' ),
     	   'gettermsNonce' => wp_create_nonce( 'myajax-term-nonce' ),

--- a/themes/wp-portugal-tema/scss/site/_styles.scss
+++ b/themes/wp-portugal-tema/scss/site/_styles.scss
@@ -1,0 +1,3 @@
+
+#term__result { padding: 10px;  min-height: 40px; background-color: rgb(226, 224, 224);  border: 1px solid rgb(131, 213, 145); }
+#gloss__block { padding: 20px; }

--- a/themes/wp-portugal-tema/templates/template-csv.php
+++ b/themes/wp-portugal-tema/templates/template-csv.php
@@ -22,15 +22,15 @@ get_header(); ?>
 				
 			<div id="gloss__block"><h2>Glossário</h2>
 			<form id     = "booking__form"
-  		class  = "form-horizontal"  
-        method = "get"  >
-				<label class="floatl" for="booking__name<?= $i ?>"><?php _e('Termo em Inglês','43lc');?></label>
+  			      class  = "form-horizontal"  
+    		      method = "get"  >
+				<label class="floatl" for="booking__name"><?php _e('Termo em Inglês','43lc');?></label>
 				<input type        ="text"  required
 				       class       ="form-control " 
 				       id          ="term__text" 
 				       name        ="term__text"
-				       value			="<?= $term__text?>"
-				       min        ="0"
+				       value	   =""
+				       min         ="0"
 				       placeholder ="<?php _e('termo*','43lc');?>">
 				       
 			

--- a/themes/wp-portugal-tema/templates/template-csv.php
+++ b/themes/wp-portugal-tema/templates/template-csv.php
@@ -1,0 +1,65 @@
+<?php 
+/** 
+ * Template Name: CSV page
+ */
+ 
+
+get_header(); ?>
+
+<div class="row">
+	<div class="small-12 large-8 columns" role="main">
+
+	<?php do_action( 'foundationpress_before_content' ); ?>
+
+	<?php while ( have_posts() ) : the_post(); ?>
+		<article <?php post_class() ?> id="post-<?php the_ID(); ?>">
+			<header>
+				<h1 class="entry-title"><?php the_title(); ?></h1>
+			</header>
+			<?php do_action( 'foundationpress_page_before_entry_content' ); ?>
+			<div class="entry-content">
+				<?php the_content(); ?>
+				
+			<div id="gloss__block"><h2>Glossário</h2>
+			<form id     = "booking__form"
+  		class  = "form-horizontal"  
+        method = "get"  >
+				<label class="floatl" for="booking__name<?= $i ?>"><?php _e('Termo em Inglês','43lc');?></label>
+				<input type        ="text"  required
+				       class       ="form-control " 
+				       id          ="term__text" 
+				       name        ="term__text"
+				       value			="<?= $term__text?>"
+				       min        ="0"
+				       placeholder ="<?php _e('termo*','43lc');?>">
+				       
+			
+			</form>
+			<h3>Resultado:</h3>
+			<p id="term__result"></p>
+			
+			</div>
+			<div id="latestterms">
+				<p id="firstresult" style="display: none;"></p>
+				
+			</div>
+			
+
+			</div>
+			<footer>
+				<?php wp_link_pages( array('before' => '<nav id="page-nav"><p>' . __( 'Pages:', 'foundationpress' ), 'after' => '</p></nav>' ) ); ?>
+				<p><?php the_tags(); ?></p>
+			</footer>
+			<?php do_action( 'foundationpress_page_before_comments' ); ?>
+			<?php comments_template(); ?>
+			<?php do_action( 'foundationpress_page_after_comments' ); ?>
+		</article>
+	<?php endwhile;?>
+
+	<?php do_action( 'foundationpress_after_content' ); ?>
+
+	</div>
+	<?php get_sidebar(); ?>
+</div>
+<?php get_footer(); ?>
+

--- a/themes/wp-portugal-tema/templates/template-csv.php
+++ b/themes/wp-portugal-tema/templates/template-csv.php
@@ -21,17 +21,17 @@ get_header(); ?>
 				<?php the_content(); ?>
 				
 			<div id="gloss__block"><h2>Glossário</h2>
-			<form id     = "booking__form"
+			<form id     = "term__form"
   			      class  = "form-horizontal"  
     		      method = "get"  >
-				<label class="floatl" for="booking__name"><?php _e('Termo em Inglês','43lc');?></label>
+				<label class="floatl" for="term__text">Termo em Inglês</label>
 				<input type        ="text"  required
 				       class       ="form-control " 
 				       id          ="term__text" 
 				       name        ="term__text"
 				       value	   =""
 				       min         ="0"
-				       placeholder ="<?php _e('termo*','43lc');?>">
+				       placeholder ="termo*">
 				       
 			
 			</form>


### PR DESCRIPTION
created a new template page for loading and searching for a term in a glossary.

the glossary is loaded from glossary.csv, and the search term is strictly compared with the possible terms in english. 

the format was based on this file: 
https://docs.google.com/spreadsheets/d/1-a2BwuOfztTfiht93pdeNaIqstju_bzn_sBMQUCp5Ig/edit?usp=sharing 
and it's something like this:
https://gist.github.com/LC43/b850b927476487740269

the code looks for a glossary.csv in the uploads dir.

i left a couple of TODO in the code. ;)

A lot more can be done like parcial comparition, multiple return values, and even search results stored in $_SESSION or at least during page view with JS.
